### PR TITLE
Added IME (on-screen keyboard) inset support to EdgeToEdgeTemplate.

### DIFF
--- a/edge_to_edge_preview_lib/README.md
+++ b/edge_to_edge_preview_lib/README.md
@@ -11,6 +11,7 @@ It now also supports the preview in Compose Multiplatform 1.10.1 and newer. But 
 - Simulate WindowInsets in Compose previews
 - Multiplatform support
 - Multiple device configurations (navigation modes, camera cutouts)
+- On-screen keyboard (IME) simulation with a keyboard placeholder
 - Visual insets border highlighting
 - Highly configurable preview templates
 - WindowInsetsRulers api is also simulated
@@ -147,6 +148,37 @@ fun PreviewWithWindowInsets() {
 }
 ```
 
+### On-screen keyboard (IME)
+
+Simulate an open on-screen keyboard to preview and screenshot-test layouts
+that use `Modifier.imePadding()` or `WindowInsets.ime`:
+
+```kotlin
+@Preview
+@Composable
+fun PreviewWithKeyboard() {
+    EdgeToEdgeTemplate(
+        cfg = InsetsConfig(
+            imeMode = InsetMode.Visible,
+            //imeSize = 250.dp // optional, 250.dp is the default
+        )
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .systemBarsPadding()
+                .imePadding()
+        ) {
+            MessageList(modifier = Modifier.weight(1f))
+            MessageInputField()
+        }
+    }
+}
+```
+
+`WindowInsets.isImeVisible` will be `true` and the keyboard placeholder is drawn
+above the navigation bar, like a real IME.
+
 ## Configuration Options
 
 ### NavigationMode
@@ -172,6 +204,7 @@ fun PreviewWithWindowInsets() {
 - `statusBarMode` - Status bar visibility mode (InsetMode)
 - `navigationBarMode` - Navigation bar visibility mode (InsetMode)
 - `captionBarMode` - Caption bar visibility mode (InsetMode, default: `InsetMode.Off`)
+- `imeMode` - On-screen keyboard (IME) simulation (InsetMode, default: `InsetMode.Off`). The keyboard size can be changed with `InsetsConfig(imeSize = ...)`
 - `isInvertedOrientation` - Invert device orientation (in landscape: camera cutout on right, nav buttons on left)
 - `isNavigationBarContrastEnforced` - Enforce navigation bar contrast (Android only)
 - `useHiddenApiHack` - Enable hidden API workarounds (Android only)

--- a/edge_to_edge_preview_lib/src/androidMain/kotlin/de/drick/compose/edgetoedgepreviewlib/edge_to_edge_template.android.kt
+++ b/edge_to_edge_preview_lib/src/androidMain/kotlin/de/drick/compose/edgetoedgepreviewlib/edge_to_edge_template.android.kt
@@ -72,6 +72,7 @@ fun EdgeToEdgeTemplateImpl(
     val captionBarSize = with(LocalDensity.current) { captionBarHeightDp.roundToPx() }
 
     val systemGestureHorizontalSize = with(LocalDensity.current) { cfg.gestureNavSize.roundToPx() }
+    val imeSize = with(LocalDensity.current) { cfg.imeSize.roundToPx() }
 
     val windowInsets = buildInsets {
         var insets = Insets.of(0,0,0,0)
@@ -111,6 +112,16 @@ fun EdgeToEdgeTemplateImpl(
                 isVisible = true
             )
             insets = insets.union(captionBarInsets)
+        }
+        if (cfg.imeMode != InsetMode.Off) {
+            // On real devices the ime inset is measured from the bottom of the screen,
+            // so it already covers the navigation bar and is not added on top of it.
+            setInset(
+                pos = InsetPos.BOTTOM,
+                type = InsetType.IME,
+                size = imeSize,
+                isVisible = cfg.imeMode == InsetMode.Visible
+            )
         }
         setInset(
             left = insets.left,
@@ -234,6 +245,18 @@ fun EdgeToEdgeTemplateImpl(
                     isDarkMode = isDarkMode,
                     navMode = cfg.navMode,
                     backgroundAlpha = if (cfg.isNavigationBarContrastEnforced) 0.5f else 0f
+                )
+            }
+            if (cfg.imeMode == InsetMode.Visible) {
+                ImeKeyboard(
+                    size = cfg.imeSize,
+                    modifier = Modifier
+                        .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal))
+                        .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal))
+                        .align(Alignment.BottomCenter)
+                        .zIndex(1002f)
+                        .clearAndSetSemantics { },
+                    isDarkMode = isDarkMode
                 )
             }
             if (cfg.showInsetsBorder && Build.VERSION.SDK_INT >= 30) {

--- a/edge_to_edge_preview_lib/src/androidMain/kotlin/de/drick/compose/edgetoedgepreviewlib/insets_builder.kt
+++ b/edge_to_edge_preview_lib/src/androidMain/kotlin/de/drick/compose/edgetoedgepreviewlib/insets_builder.kt
@@ -105,7 +105,11 @@ fun buildInsets(block: InsetsDsl.() -> Unit): WindowInsetsCompat  {
             if (isVisible) {
                 builder.setInsets(type.getTypeMask(), insets)
             }
-            builder.setInsetsIgnoringVisibility(type.getTypeMask(), insets)
+            // setInsetsIgnoringVisibility is not defined for the IME type and
+            // throws an IllegalArgumentException on API 30+
+            if (type != InsetType.IME) {
+                builder.setInsetsIgnoringVisibility(type.getTypeMask(), insets)
+            }
             builder.setVisible(type.getTypeMask(), isVisible)
             return insets
         }

--- a/edge_to_edge_preview_lib/src/commonMain/kotlin/de/drick/compose/edgetoedgepreviewlib/edge_to_edge_template.kt
+++ b/edge_to_edge_preview_lib/src/commonMain/kotlin/de/drick/compose/edgetoedgepreviewlib/edge_to_edge_template.kt
@@ -44,6 +44,14 @@ data class InsetsConfig(
     val captionBarMode: InsetMode = InsetMode.Off,
     val captionBarSize: Dp = 42.dp,
     val gestureNavSize: Dp = 30.dp,
+    /**
+     * Simulates an open on-screen keyboard (IME).
+     * [InsetMode.Visible] sets the ime inset and shows a keyboard placeholder.
+     * [InsetMode.Hidden] behaves like on a real device when the keyboard is closed
+     * (ime inset is 0 and not visible), so it is effectively the same as [InsetMode.Off].
+     */
+    val imeMode: InsetMode = InsetMode.Off,
+    val imeSize: Dp = 250.dp,
 ) {
     companion object {
         val Default = InsetsConfig()
@@ -77,6 +85,7 @@ fun EdgeToEdgeTemplate(
     navigationBarMode: InsetMode = InsetMode.Visible,
     isNavigationBarContrastEnforced: Boolean = true,
     captionBarMode: InsetMode = InsetMode.Off,
+    imeMode: InsetMode = InsetMode.Off,
     content: @Composable () -> Unit
 ) {
     val config = InsetsConfig(
@@ -84,6 +93,7 @@ fun EdgeToEdgeTemplate(
         statusBarMode = statusBarMode,
         navigationBarMode = navigationBarMode,
         captionBarMode = captionBarMode,
+        imeMode = imeMode,
         cameraCutoutMode = cameraCutoutMode,
         isInvertedOrientation = isInvertedOrientation,
         showInsetsBorder = showInsetsBorder,

--- a/edge_to_edge_preview_lib/src/commonMain/kotlin/de/drick/compose/edgetoedgepreviewlib/ime_keyboard.kt
+++ b/edge_to_edge_preview_lib/src/commonMain/kotlin/de/drick/compose/edgetoedgepreviewlib/ime_keyboard.kt
@@ -1,0 +1,165 @@
+package de.drick.compose.edgetoedgepreviewlib
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Preview(name = "Ime keyboard", widthDp = 400)
+@Composable
+private fun PreviewImeKeyboard() {
+    ImeKeyboard(
+        size = 250.dp,
+        isDarkMode = true
+    )
+}
+
+@Preview(name = "Ime keyboard light", widthDp = 400)
+@Composable
+private fun PreviewImeKeyboardLight() {
+    ImeKeyboard(
+        size = 250.dp,
+        isDarkMode = false
+    )
+}
+
+private val keyRow1 = "qwertyuiop".map { it.toString() }
+private val keyRow1Hints = "1234567890".map { it.toString() }
+private val keyRow2 = "asdfghjkl".map { it.toString() }
+private val keyRow3 = "zxcvbnm".map { it.toString() }
+
+/**
+ * Placeholder that simulates an open on-screen keyboard (IME).
+ */
+@Composable
+fun ImeKeyboard(
+    size: Dp,
+    modifier: Modifier = Modifier,
+    isDarkMode: Boolean = true,
+) {
+    val backgroundColor = if (isDarkMode) Color(0xFF22262A) else Color(0xFFECEEF1)
+    val keyColor = if (isDarkMode) Color(0xFF3C4046) else Color(0xFFFBFCFE)
+    val functionKeyColor = if (isDarkMode) Color(0xFF51555B) else Color(0xFFD4D8DE)
+    val contentColor = if (isDarkMode) Color(0xFFE8EAED) else Color(0xFF1F2328)
+    val colors = ImeKeyboardColors(
+        key = keyColor,
+        functionKey = functionKeyColor,
+        content = contentColor
+    )
+    Column(
+        modifier = modifier
+            .height(size)
+            .fillMaxWidth()
+            .background(backgroundColor)
+            // like a real IME keep the keys out of the navigation bar area
+            // while the keyboard background is drawn behind the navigation bar
+            .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom))
+            .padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        KeyRow {
+            keyRow1.forEachIndexed { index, letter ->
+                Key(letter, colors, hint = keyRow1Hints[index])
+            }
+        }
+        KeyRow {
+            Spacer(Modifier.weight(0.5f))
+            keyRow2.forEach { letter ->
+                Key(letter, colors)
+            }
+            Spacer(Modifier.weight(0.5f))
+        }
+        KeyRow {
+            Key("", colors, weight = 1.5f, isFunctionKey = true) // shift
+            keyRow3.forEach { letter ->
+                Key(letter, colors)
+            }
+            Key("", colors, weight = 1.5f, isFunctionKey = true) // backspace
+        }
+        KeyRow {
+            Key("?123", colors, weight = 1.5f, isFunctionKey = true)
+            Key(",", colors)
+            Key("", colors) // emoji
+            Key("", colors, weight = 4f) // space
+            Key(".", colors)
+            Key("", colors, weight = 1.5f, isFunctionKey = true) // search
+        }
+    }
+}
+
+private class ImeKeyboardColors(
+    val key: Color,
+    val functionKey: Color,
+    val content: Color
+)
+
+@Composable
+private fun ColumnScope.KeyRow(
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
+        modifier = Modifier.weight(1f).fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        content = content
+    )
+}
+
+@Composable
+private fun RowScope.Key(
+    label: String,
+    colors: ImeKeyboardColors,
+    weight: Float = 1f,
+    hint: String? = null,
+    isFunctionKey: Boolean = false
+) {
+    Box(
+        modifier = Modifier
+            .weight(weight)
+            .fillMaxHeight()
+            .background(
+                color = if (isFunctionKey) colors.functionKey else colors.key,
+                shape = RoundedCornerShape(6.dp)
+            )
+    ) {
+        BasicText(
+            text = label,
+            modifier = Modifier.align(Alignment.Center),
+            style = TextStyle(fontSize = 18.sp),
+            color = { colors.content }
+        )
+        if (hint != null) {
+            BasicText(
+                text = hint,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 2.dp, end = 5.dp),
+                style = TextStyle(fontSize = 10.sp),
+                color = { colors.content }
+            )
+        }
+    }
+}

--- a/samples/edge_to_edge_preview/src/main/java/de/drick/compose/edgetoedgepreview/edge_to_edge_ime_sample.kt
+++ b/samples/edge_to_edge_preview/src/main/java/de/drick/compose/edgetoedgepreview/edge_to_edge_ime_sample.kt
@@ -1,0 +1,75 @@
+package de.drick.compose.edgetoedgepreview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import de.drick.compose.edgetoedgepreview.ui.theme.ComposeLibrariesTheme
+import de.drick.compose.edgetoedgepreviewlib.EdgeToEdgeTemplate
+import de.drick.compose.edgetoedgepreviewlib.InsetMode
+import de.drick.compose.edgetoedgepreviewlib.InsetsConfig
+
+@GridScreenPreview
+@Composable
+private fun PreviewEdgeToEdgeImeThreeButtonNav() {
+    EdgeToEdgeTemplate(
+        cfg = InsetsConfig(imeMode = InsetMode.Visible)
+    ) {
+        ComposeLibrariesTheme {
+            ImeSampleContent()
+        }
+    }
+}
+
+@GridScreenPreview
+@Composable
+private fun PreviewEdgeToEdgeImeGestureNav() {
+    EdgeToEdgeTemplate(
+        cfg = InsetsConfig.GestureNav.copy(imeMode = InsetMode.Visible)
+    ) {
+        ComposeLibrariesTheme {
+            ImeSampleContent()
+        }
+    }
+}
+
+@Composable
+private fun ImeSampleContent() {
+    var text by remember { mutableStateOf("") }
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .systemBarsPadding()
+            .imePadding()
+    ) {
+        Text(
+            text = "Messages",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(16.dp)
+        )
+        Spacer(Modifier.weight(1f))
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            placeholder = { Text("Type a message") }
+        )
+    }
+}

--- a/samples/edge_to_edge_preview/src/test/java/de/drick/compose/edgetoedgepreview/edge_to_edge_ime_test_robolectric.kt
+++ b/samples/edge_to_edge_preview/src/test/java/de/drick/compose/edgetoedgepreview/edge_to_edge_ime_test_robolectric.kt
@@ -1,0 +1,124 @@
+package de.drick.compose.edgetoedgepreview
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import de.drick.compose.edgetoedgepreviewlib.EdgeToEdgeTemplate
+import de.drick.compose.edgetoedgepreviewlib.InsetMode
+import de.drick.compose.edgetoedgepreviewlib.InsetsConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowLog
+import java.io.File
+
+@Config(sdk = [36])
+@RunWith(RobolectricTestRunner::class)
+class EdgeToEdgeImeTestRobolectric {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        ShadowLog.stream = System.out // Redirect Logcat to console
+        RuntimeEnvironment.setQualifiers("w360dp-h640dp-xxhdpi")
+    }
+
+    @OptIn(ExperimentalLayoutApi::class)
+    @Test
+    @GraphicsMode(GraphicsMode.Mode.NATIVE)
+    fun imeModeVisibleInjectsImeInsetsAtBottom() {
+        val imeSize = 250.dp
+        var isImeVisible = false
+        var imeBottomPx = -1
+        var navigationBarBottomPx = -1
+        var expectedImePx = -1
+        composeTestRule.setContent {
+            EdgeToEdgeTemplate(
+                modifier = Modifier.testTag("edge_to_edge"),
+                cfg = InsetsConfig(
+                    imeMode = InsetMode.Visible,
+                    imeSize = imeSize
+                )
+            ) {
+                val density = LocalDensity.current
+                expectedImePx = with(density) { imeSize.roundToPx() }
+                isImeVisible = WindowInsets.isImeVisible
+                imeBottomPx = WindowInsets.ime.getBottom(density)
+                navigationBarBottomPx = WindowInsets.navigationBars.getBottom(density)
+                Box(Modifier.fillMaxSize().background(Color.White)) {
+                    // marker that should sit directly on top of the keyboard placeholder
+                    Box(
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .imePadding()
+                            .fillMaxWidth()
+                            .height(20.dp)
+                            .background(Color.Red)
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertTrue("WindowInsets.isImeVisible should be true", isImeVisible)
+        assertEquals("IME bottom inset", expectedImePx, imeBottomPx)
+        assertTrue(
+            "IME inset should cover the navigation bar (ime >= nav bar)",
+            imeBottomPx >= navigationBarBottomPx
+        )
+        System.setProperty("robolectric.screenshot.hwrdr.native", "true")
+        val bitmap = composeTestRule
+            .onNodeWithTag("edge_to_edge")
+            .captureToImage()
+            .asAndroidBitmap()
+        File("ime_visible_screenshot.png").outputStream().use {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    @OptIn(ExperimentalLayoutApi::class)
+    @Test
+    fun defaultConfigHasNoImeInsets() {
+        var isImeVisible = true
+        var imeBottomPx = -1
+        composeTestRule.setContent {
+            EdgeToEdgeTemplate(
+                cfg = InsetsConfig()
+            ) {
+                isImeVisible = WindowInsets.isImeVisible
+                imeBottomPx = WindowInsets.ime.getBottom(LocalDensity.current)
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertFalse("WindowInsets.isImeVisible should be false by default", isImeVisible)
+        assertEquals("IME bottom inset should be 0 by default", 0, imeBottomPx)
+    }
+}


### PR DESCRIPTION
Implements IME inset simulation as discussed in #18 .

- New `InsetsConfig` options: `imeMode: InsetMode = InsetMode.Off` and `imeSize: Dp = 250.dp` (`imeMode` also available in the convenience `EdgeToEdgeTemplate(...)` overload).
- When visible, the ime inset is injected at the bottom (covering the navigation bar, like on real devices) and a keyboard placeholder is drawn, so layouts using `Modifier.imePadding()` / `WindowInsets.ime` react to it.
- Note: `buildInsets` now skips `setInsetsIgnoringVisibility` for the IME type — it throws `IllegalArgumentException` on API 30+.

Use case: previews and screenshot tests (Paparazzi/Robolectric) of screens in the "keyboard open" state. Default is `Off`, so existing usages are unaffected.

Tested with a new Robolectric test (`EdgeToEdgeImeTestRobolectric`) plus new sample previews; existing tests still pass and all KMP targets compile.

Preview:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/582735d3-78e6-4e01-94b3-0dc26c3442ad" />
